### PR TITLE
Fixed ACTION_CHECKBOX_NAME admin import

### DIFF
--- a/raster_aggregation/admin.py
+++ b/raster_aggregation/admin.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from raster.models import RasterLayer
 
 from django import forms
+from django.contrib.admin.helpers import ACTION_CHECKBOX_NAME
 from django.contrib.gis import admin
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
@@ -72,7 +73,7 @@ class ComputeActivityAggregatesModelAdmin(admin.ModelAdmin):
         # Before posting, prepare empty action form
         if not form:
             form = SelectLayerActionForm(initial={
-                '_selected_action': request.POST.getlist(admin.ACTION_CHECKBOX_NAME),
+                '_selected_action': request.POST.getlist(ACTION_CHECKBOX_NAME),
             })
 
         return render(


### PR DESCRIPTION
Seems like ACTION_CHECKBOX_NAME was inside `django.contrib.admin` for historical reasons and was removed in django 3.1

https://github.com/django/django/commit/4c45b627f8c05aaa60f0989f5a41aefe8d107b57#diff-7748bd5505aa29c1aa28ee9383ceb34a2353eed240a098d442e2702fd12a82ef

But even before that, the helpers are not included in `django.contrib.gis.admin`, so `ACTION_CHECKBOX_NAME` needs to be imported directly from the non gis admin helpers.